### PR TITLE
Added hyperlinks

### DIFF
--- a/lib/Locale/Country.pod
+++ b/lib/Locale/Country.pod
@@ -74,7 +74,7 @@ with a few other additions.
 =back
 
 NOTE: As of version 3.27, the FIPS code set is no longer supported.  See the
-Locale::Codes::Changes document for details.
+L<Locale::Codes::Changes> document for details.
 
 =head1 ROUTINES
 
@@ -106,7 +106,7 @@ Locale::Codes::Changes document for details.
 
 =item B<Locale::Country::delete_country_code_alias  ( CODE [,CODESET] )>
 
-These routines are all documented in the Locale::Codes::API man page.
+These routines are all documented in the L<Locale::Codes::API> man page.
 
 =item B<alias_code ( ALIAS, CODE [,CODESET] )>
 
@@ -137,35 +137,35 @@ all 2.X releases, but has been dropped as of 3.00.
 
 =over 4
 
-=item B<Locale::Codes>
+=item L<Locale::Codes>
 
 The Locale-Codes distribution.
 
-=item B<Locale::Codes::API>
+=item L<Locale::Codes::API>
 
 The list of functions supported by this module.
 
-=item B<Locale::SubCountry>
+=item L<Locale::SubCountry>
 
 ISO codes for country sub-divisions (states, counties, provinces,
 etc), as defined in ISO 3166-2.  This module is not part of the
 Locale-Codes distribution, but is available from CPAN in
 CPAN/modules/by-module/Locale/
 
-=item B<http://www.iso.org/iso/home/standards/country_codes.htm>
+=item L<http://www.iso.org/iso/home/standards/country_codes.htm>
 
 Official home page for the ISO 3166 maintenance agency.
 
-=item B<http://www.iso.org/iso/home/standards/country_codes/iso-3166-1_decoding_table.htm>
+=item L<http://www.iso.org/iso/home/standards/country_codes/iso-3166-1_decoding_table.htm>
 
 The source of ISO 3166-1 two-letter codes used by this
 module.
 
-=item B<http://www.iana.org/domains/root/db/>
+=item L<http://www.iana.org/domains/root/db/>
 
 Official source of the top-level domain names.
 
-=item B<http://unstats.un.org/unsd/methods/m49/m49alpha.htm>
+=item L<http://unstats.un.org/unsd/methods/m49/m49alpha.htm>
 
 The source of the official ISO 3166-1 three-letter codes and
 three-digit codes.
@@ -174,13 +174,13 @@ For some reason, this table is incomplete! Several countries are
 missing from it, and I cannot find them anywhere on the UN site.  I
 no longer use this as a source of data.
 
-=item B<https://www.cia.gov/library/publications/the-world-factbook/appendix/print_appendix-d.html>
+=item L<https://www.cia.gov/library/publications/the-world-factbook/appendix/print_appendix-d.html>
 
 The World Factbook maintained by the CIA is a potential source of
 the data.  Unfortunately, it adds/preserves non-standard codes, so it is no
 longer used as a source of data.
 
-=item B<http://www.statoids.com/wab.html>
+=item L<http://www.statoids.com/wab.html>
 
 Another unofficial source of data. Currently, it is not used to get
 data, but the notes and explanatory material were very useful for
@@ -190,7 +190,7 @@ understanding discrepancies between the sources.
 
 =head1 AUTHOR
 
-See Locale::Codes for full author history.
+See L<Locale::Codes> for full author history.
 
 Currently maintained by Sullivan Beck (sbeck@cpan.org).
 


### PR DESCRIPTION
The references to other modules in this dist and the third-party URLs in "See Also" were not links. This commit converts them into hyperlinks.

I was browsing this document today and thought that these links (particularly the one to Locale::Codes::API which documents some of the functions listed on this page) would be useful.
